### PR TITLE
Optional default value for hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ function MyComponent({id}){
     const options = { 
         fn: () => Promise.resolve({})), 
         initialFetch: false, 
-        debug: false 
+        debug: false,
+        default: []
     }
     const { data, loading, error, refetch } = useDataHook(options, asyncParameters);
 
@@ -88,6 +89,7 @@ The asyncParameters can be one or more arguments that will be used to call the a
 | **fn** | undefined | true | Async function that returns a Promise
 | **initialFetch** | false | false | Should a request be made on mount
 | **debug** | false | false | Console log debug information
+| **default** | null | false | optional default value
 
 Look at the example in the ./example folder for a type-ahead input field using this hook.
 

--- a/index.ts
+++ b/index.ts
@@ -27,7 +27,7 @@ function useAsyncDataHook(options: asyncDataHookArguments, ...rest) {
   const [state, setState] = useState({
     loading: initialFetch,
     error: null,
-    data: null,
+    data: options.default || null,
   });
 
   const refetch = useCallback((...newArgs) => {


### PR DESCRIPTION
There will be cases like just iterate over the dataset without showing a loading, error.

for example 
```js
const {data} = useData(fn, {default: []});
```

by allowing default value we can avoid the check for the null